### PR TITLE
Modify ExPromptDialog.vue

### DIFF
--- a/docs/pages/components/dialog/examples/ExPromptDialog.vue
+++ b/docs/pages/components/dialog/examples/ExPromptDialog.vue
@@ -43,8 +43,8 @@ export default {
                     type: 'number',
                     placeholder: 'Type your age',
                     value: '18',
-                    maxlength: 2,
-                    min: 18
+                    min: 18,
+                    max: 99
                 },
                 trapFocus: true,
                 onConfirm: (value) => this.$buefy.toast.open(`Your age is: ${value}`)


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Remove `maxLength` option from the `inputAttrs` (Because it does not working properly when type is number)
- Add `max` option to the `inputAttrs` instead of `maxLength`
